### PR TITLE
Use native accessor for handler map interactions

### DIFF
--- a/addon/services/unified-event-handler.js
+++ b/addon/services/unified-event-handler.js
@@ -122,11 +122,10 @@ export default Ember.Service.extend(Ember.Evented, {
       };
 
       if (!targetHandlers) {
-        this[_HANDLER_MAP][target] = Object.create(null);
-        this[_HANDLER_MAP][target][eventName] = handlerInfo;
-      } else {
-        targetHandlers[eventName] = handlerInfo;
+        handlerMap[target] = targetHandlers = Object.create(null);
       }
+
+      targetHandlers[eventName] = handlerInfo;
     }
 
     return handlerInfo;
@@ -208,7 +207,9 @@ export default Ember.Service.extend(Ember.Evented, {
    * @return {Object}
    */
   _getTargetEventHandler(target, eventName) {
-    return this.get(`${_HANDLER_MAP}.${target}.${eventName}`);
+    let handlerMap = this[_HANDLER_MAP];
+    let targetHandlers = handlerMap && handlerMap[target];
+    return targetHandlers && targetHandlers[eventName] || undefined;
   },
 
   /**

--- a/tests/unit/services/unified-event-handler-test.js
+++ b/tests/unit/services/unified-event-handler-test.js
@@ -78,21 +78,30 @@ test('unregisters multiple event listeners of different event types when service
 });
 
 test('register binds multiple callbacks to the event on the specified target but only triggers once', function(assert) {
-  assert.expect(3);
+  assert.expect(4);
 
   let callback1Stub = sandbox.stub();
   let callback2Stub = sandbox.stub();
   let triggerSpy = sandbox.spy(service, 'triggerEvent');
 
-  service.register('window', 'scroll', callback1Stub);
-  service.register('window', 'scroll', callback2Stub);
-  window.dispatchEvent(new CustomEvent('scroll'));
-  assert.ok(callback1Stub.calledOnce);
-  assert.ok(callback2Stub.calledOnce);
-  assert.ok(triggerSpy.calledOnce);
+  let testContainer = document.getElementById('ember-testing');
+  let element = document.createElement('p');
+  element.classList.add('foo');
+  testContainer.appendChild(element);
+  let addEventListenerSpy = sandbox.spy(element, 'addEventListener');
 
-  service.unregister('window', 'scroll', callback1Stub);
-  service.unregister('window', 'scroll', callback2Stub);
+  service.register('p.foo', 'scroll', callback1Stub);
+  service.register('p.foo', 'scroll', callback2Stub);
+  assert.ok(addEventListenerSpy.calledOnce, 'event listener added only once');
+
+  element.dispatchEvent(new CustomEvent('scroll'));
+  assert.ok(callback1Stub.calledOnce, 'first callback executed');
+  assert.ok(callback2Stub.calledOnce, 'second callback executed');
+  assert.ok(triggerSpy.calledOnce, 'trigger called only once');
+
+  service.unregister('p.foo', 'scroll', callback1Stub);
+  service.unregister('p.foo', 'scroll', callback2Stub);
+  testContainer.removeChild(element);
 });
 
 test('register binds callbacks to multiple events on the specified target', function(assert) {


### PR DESCRIPTION
Most interactions with `_handlerMap` already use native accessors (dots and square brackets). However, the one in `_getTargetEventHandler` uses `Ember.get`.

This creates an issue for class selector strings as they begin with a dot (e.g. `.actor-list`). In order to use `Ember.Object`'s getter, the target is included in a property path string. Property path strings use dots to delimit properties, so the path becomes, for example, `_handlerMap..actor-list.click`.

This causes an error to be thrown in recent versions of Ember, which assert that `Ember.get` is not used with an empty string as the property name. The `..` substring is interpreted by `Ember.get` to delimit an additional property name on the property path, which has a length of zero, i.e. an empty string.

Additionally, it stands to reason that any selector that contains a class would produce an unexpected result. Take `unifiedEventHandler.register('a.foo', 'click', onClick);` for instance. This will cause the property path `_handlerMap.a.foo.click` to be looked up on the service, which is akin to `this['_handlerMap']['a']['foo']['click']`. However, any existing handler will have been stored at `this['_handlerMap']['a.foo']['click']`, leading the property lookup via `Ember.get` to return `undefined` instead of the existing handler.

N.B. This PR doesn't fix the lack of account for different selectors targeting the same element.