### PR TITLE
1:1 mapping between events and throttle methods

### DIFF
--- a/addon/services/unified-event-handler.js
+++ b/addon/services/unified-event-handler.js
@@ -106,8 +106,8 @@ export default Ember.Service.extend(Ember.Evented, {
     if (!handlerInfo) {
       // Add new DOM event listener since there is none
       let emberEventName = `${eventName}.${generateId()}`;
-      const throttledEventCallback = this._generateEventThrottler(emberEventName);
-      let trigger = this._runThrottler.bind(this, throttledEventCallback);
+      const throttledEventCallback = () => this.trigger(emberEventName);
+      let trigger = this._runThrottle.bind(this, throttledEventCallback);
       let targetElement = this._lookupElement(target);
 
       targetElement.addEventListener(eventName, trigger);
@@ -220,23 +220,12 @@ export default Ember.Service.extend(Ember.Evented, {
   },
 
   /**
-   * Creates a function that is used as a handler when throttling events. This makes it possible
-   * for the same throttler function to be used for the same event name
-   * @private
-   * @param {String} emberEventName - The ember event to trigger once throttling completes
-   * @return {function}
-   */
-  _generateEventThrottler(emberEventName) {
-    return () => this.trigger(emberEventName);
-  },
-
-  /**
    * Triggers a given Ember event at a throttled rate
    * @private
    * @param {Function} throttledEventCallback - A method that will be called at a throttled rate
    * @return {Void}
    */
-  _runThrottler(throttledEventCallback) {
+  _runThrottle(throttledEventCallback) {
     const throttleId = Ember.run.throttle(this, throttledEventCallback, EVENT_INTERVAL);
     this._throttledEventTimers.push(throttleId);
   },

--- a/addon/services/unified-event-handler.js
+++ b/addon/services/unified-event-handler.js
@@ -122,7 +122,6 @@ export default Ember.Service.extend(Ember.Evented, {
         targetElement,
         throttledEventCallback,
         emberHandlers: [],
-        throttledEvent: this._generateThrottledTriggerFn(),
       };
 
       if (!targetHandlers) {

--- a/tests/unit/services/unified-event-handler-test.js
+++ b/tests/unit/services/unified-event-handler-test.js
@@ -45,7 +45,12 @@ test('unregisters event listeners when service is destroyed', function(assert) {
 test('cancels throttled events when service is destroyed', function(assert) {
   assert.expect(1);
 
-  service.triggerEvent('scroll');
+  let callbackStub = sandbox.stub();
+  service.register('window', 'scroll', callbackStub);
+
+  for (let i = 0; i < 500; i++) {
+    service.triggerEvent('window', 'scroll');
+  }
 
   Ember.run(service, 'destroy');
 
@@ -227,9 +232,11 @@ test('triggerEvent triggers the event at a throttled rate', function(assert) {
   let throttleSpy = sandbox.spy(Ember.run, 'throttle');
   let callbackStub = sandbox.stub();
 
-  service.on('testing', callbackStub);
-  service.triggerEvent('testing');
+  service.register('window', 'scroll', callbackStub);
+  window.dispatchEvent(new CustomEvent('scroll'));
 
   assert.ok(throttleSpy.calledOnce);
   assert.ok(callbackStub.calledOnce);
+
+  service.unregister('window', 'scroll', callbackStub);
 });

--- a/tests/unit/services/unified-event-handler-test.js
+++ b/tests/unit/services/unified-event-handler-test.js
@@ -45,8 +45,8 @@ test('unregisters event listeners when service is destroyed', function(assert) {
 test('cancels throttled events when service is destroyed', function(assert) {
   assert.expect(1);
 
-  let callbackStub = sandbox.stub();
-  service.register('window', 'scroll', callbackStub);
+  let callback = sandbox.stub();
+  service.register('window', 'scroll', callback);
 
   for (let i = 0; i < 500; i++) {
     window.dispatchEvent(new CustomEvent('scroll'));
@@ -95,11 +95,10 @@ test('unregisters multiple event listeners of different event types when service
 });
 
 test('register binds multiple callbacks to the event on the specified target but only triggers once', function(assert) {
-  assert.expect(4);
+  assert.expect(3);
 
   let callback1Stub = sandbox.stub();
   let callback2Stub = sandbox.stub();
-  let triggerSpy = sandbox.spy(service, '_runThrottler');
 
   let testContainer = document.getElementById('ember-testing');
   let element = document.createElement('p');
@@ -114,7 +113,6 @@ test('register binds multiple callbacks to the event on the specified target but
   element.dispatchEvent(new CustomEvent('scroll'));
   assert.ok(callback1Stub.calledOnce, 'first callback executed');
   assert.ok(callback2Stub.calledOnce, 'second callback executed');
-  assert.ok(triggerSpy.calledOnce, 'trigger called only once');
 
   service.unregister('p.foo', 'scroll', callback1Stub);
   service.unregister('p.foo', 'scroll', callback2Stub);
@@ -192,50 +190,44 @@ test('unregister unbinds the callback from its event but leaves other callbacks 
 });
 
 test('unregister destroys the DOM handler after all callbacks have been unbound', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
 
-  let callbackSpy = sandbox.stub();
-  let triggerSpy = sandbox.spy(service, '_runThrottler');
+  let callback = sandbox.stub();
 
-  service.register('window', 'scroll', callbackSpy);
-  service.unregister('window', 'scroll', callbackSpy);
+  service.register('window', 'scroll', callback);
+  service.unregister('window', 'scroll', callback);
   window.dispatchEvent(new CustomEvent('scroll'));
 
-  assert.ok(callbackSpy.notCalled);
-  assert.ok(triggerSpy.notCalled);
+  assert.ok(callback.notCalled);
 });
 
 test('unregister destroys the DOM handler for an event after all callbacks have been unbound but leaves other events', function(assert) {
-  assert.expect(3);
+  assert.expect(2);
 
-  let callback1Spy = sandbox.stub();
-  let callback2Spy = sandbox.stub();
-  let triggerSpy = sandbox.spy(service, '_runThrottler');
+  let callback1 = sandbox.stub();
+  let callback2 = sandbox.stub();
 
-  service.register('window', 'scroll', callback1Spy);
-  service.register('window', 'resize', callback2Spy);
-  service.unregister('window', 'scroll', callback1Spy);
+  service.register('window', 'scroll', callback1);
+  service.register('window', 'resize', callback2);
+  service.unregister('window', 'scroll', callback1);
   window.dispatchEvent(new CustomEvent('resize'));
 
-  assert.ok(callback1Spy.notCalled);
-  assert.ok(callback2Spy.calledOnce);
-  assert.ok(triggerSpy.calledOnce);
+  assert.ok(callback1.notCalled);
+  assert.ok(callback2.calledOnce);
 
-  service.unregister('window', 'resize', callback2Spy);
+  service.unregister('window', 'resize', callback2);
 });
 
 /* triggerEvent */
 
 test('triggerEvent triggers the event at a throttled rate', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
 
-  let throttleSpy = sandbox.spy(Ember.run, 'throttle');
   let callbackStub = sandbox.stub();
 
   service.register('window', 'scroll', callbackStub);
   window.dispatchEvent(new CustomEvent('scroll'));
 
-  assert.ok(throttleSpy.calledOnce);
   assert.ok(callbackStub.calledOnce);
 
   service.unregister('window', 'scroll', callbackStub);

--- a/tests/unit/services/unified-event-handler-test.js
+++ b/tests/unit/services/unified-event-handler-test.js
@@ -49,7 +49,7 @@ test('cancels throttled events when service is destroyed', function(assert) {
   service.register('window', 'scroll', callbackStub);
 
   for (let i = 0; i < 500; i++) {
-    service.triggerEvent('window', 'scroll');
+    window.dispatchEvent(new CustomEvent('scroll'));
   }
 
   Ember.run(service, 'destroy');
@@ -99,7 +99,7 @@ test('register binds multiple callbacks to the event on the specified target but
 
   let callback1Stub = sandbox.stub();
   let callback2Stub = sandbox.stub();
-  let triggerSpy = sandbox.spy(service, 'triggerEvent');
+  let triggerSpy = sandbox.spy(service, '_runThrottler');
 
   let testContainer = document.getElementById('ember-testing');
   let element = document.createElement('p');
@@ -195,7 +195,7 @@ test('unregister destroys the DOM handler after all callbacks have been unbound'
   assert.expect(2);
 
   let callbackSpy = sandbox.stub();
-  let triggerSpy = sandbox.spy(service, 'triggerEvent');
+  let triggerSpy = sandbox.spy(service, '_runThrottler');
 
   service.register('window', 'scroll', callbackSpy);
   service.unregister('window', 'scroll', callbackSpy);
@@ -210,7 +210,7 @@ test('unregister destroys the DOM handler for an event after all callbacks have 
 
   let callback1Spy = sandbox.stub();
   let callback2Spy = sandbox.stub();
-  let triggerSpy = sandbox.spy(service, 'triggerEvent');
+  let triggerSpy = sandbox.spy(service, '_runThrottler');
 
   service.register('window', 'scroll', callback1Spy);
   service.register('window', 'resize', callback2Spy);


### PR DESCRIPTION
Throttle wasn't actually working in previous versions, because we were using anonymous functions as the method to throttle, so backburner would never get a handle to the throttled method.