### PR TITLE
Passes the original event through to the registered callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,16 @@ ensure the benefits described in the above motivations.
 
 This registers a callback to be tied to a specific target and event type. The
 `target` and `eventName` are expected to be of type `string` and `callback` is a
-function. Here's an example:
+function. The `callback` will receive the original event. Here's an example:
 
 ```js
 let ScrollMixin = Ember.Mixin.extend({
   unifiedEventHandler: Ember.inject.service(),
 
   _registerScrollCallback: Ember.on('init', function() {
-    this.get('unifiedEventHandler').register('window', 'scroll', () => {
+    this.get('unifiedEventHandler').register('window', 'scroll', (event) => {
       console.log('scrolled!');
+      console.log(event);
     });
   })
 });

--- a/addon/services/unified-event-handler.js
+++ b/addon/services/unified-event-handler.js
@@ -106,7 +106,7 @@ export default Ember.Service.extend(Ember.Evented, {
     if (!handlerInfo) {
       // Add new DOM event listener since there is none
       let emberEventName = `${eventName}.${generateId()}`;
-      const throttledEventCallback = () => this.trigger(emberEventName);
+      const throttledEventCallback = (originalEvent) => this.trigger(emberEventName, originalEvent);
       let trigger = this._runThrottle.bind(this, throttledEventCallback);
       let targetElement = this._lookupElement(target);
 
@@ -225,8 +225,8 @@ export default Ember.Service.extend(Ember.Evented, {
    * @param {Function} throttledEventCallback - A method that will be called at a throttled rate
    * @return {Void}
    */
-  _runThrottle(throttledEventCallback) {
-    const throttleId = Ember.run.throttle(this, throttledEventCallback, EVENT_INTERVAL);
+  _runThrottle(throttledEventCallback, originalEvent) {
+    const throttleId = Ember.run.throttle(this, throttledEventCallback, originalEvent, EVENT_INTERVAL);
     this._throttledEventTimers.push(throttleId);
   },
 });

--- a/tests/unit/services/unified-event-handler-test.js
+++ b/tests/unit/services/unified-event-handler-test.js
@@ -161,6 +161,22 @@ test('register binds callbacks to different events on multiple targets', functio
   service.unregister('document', 'scroll', callback2Stub);
 });
 
+test('registered callbacks will recieve the original event', function(assert) {
+  assert.expect(1);
+
+  const callback1Stub = sandbox.spy();
+
+  service.register('window', 'keyup', callback1Stub);
+
+  const customEvent = new CustomEvent('keyup');
+
+  window.dispatchEvent(customEvent);
+
+  assert.ok(callback1Stub.calledWith(customEvent));
+
+  service.unregister('window', 'keyup', callback1Stub);
+});
+
 /* unregister */
 
 test('unregister unbinds the callback from its event', function(assert) {


### PR DESCRIPTION
* Adds unit tests to ensure the event is passed through un-manipulated
* Updates the unified-event-handler service to propagate the original event through to the registered callback
* Adds some notes to the README
closes #19