### PR TITLE
Updates .travis.yml to ensure correct permissions for chrome headless sandbox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   # so that your addon works for all apps
   - "4"
 
-sudo: false
+sudo: required
 dist: trusty
 
 addons:


### PR DESCRIPTION
Current travis builds are failing because of a permissions issue in chrome headless, forcing travis to use `sudo` fixes the issue
Fixes #22 
Related to: https://github.com/travis-ci/travis-ci/issues/8836