### PR TITLE
Configurable event interval

### DIFF
--- a/tests/unit/services/unified-event-handler-test.js
+++ b/tests/unit/services/unified-event-handler-test.js
@@ -248,3 +248,19 @@ test('triggerEvent triggers the event at a throttled rate', function(assert) {
 
   service.unregister('window', 'scroll', callbackStub);
 });
+
+/* Event interval */
+test('runThrottle is called with passed event interval', function(assert) {
+  assert.expect(1);
+
+  let callbackStub = sandbox.stub();
+  let interval = 10;
+  let runThrottleSpy = sandbox.spy(service, '_runThrottle')
+
+  service.register('window', 'scroll', callbackStub, interval);
+  window.dispatchEvent(new CustomEvent('scroll'));
+
+  assert.ok(runThrottleSpy.calledWithExactly(sinon.match.any, interval, sinon.match.any));
+
+  service.unregister('window', 'scroll', callbackStub);
+});


### PR DESCRIPTION
The throttle time interval is hard coded to 50ms with a TODO to make it configurable. This PR takes care of it

Changes:
The register method takes an additional param `eventInterval` which will be used to determine the throttle rate for event dispatch