### PR TITLE
Adds soft-unregister support

### DIFF
--- a/addon/services/unified-event-handler.js
+++ b/addon/services/unified-event-handler.js
@@ -190,7 +190,19 @@ export default Ember.Service.extend(Ember.Evented, {
       // Get the handler for the passed in id
       let handlerMap = this[_HANDLER_MAP];
       let handlerTarget = handlerMap[target];
+
+      // exit early as this targets events were previously unregistered
+      if (!handlerTarget) {
+        return;
+      }
+
       let handlerInfo = handlerTarget[eventName];
+
+      // exit early as this targets event has been unregistered
+      if (!handlerInfo) {
+        return;
+      }
+
       let targetElement = handlerInfo.targetElement;
 
       // Remove the associated Ember event listener

--- a/tests/unit/services/unified-event-handler-test.js
+++ b/tests/unit/services/unified-event-handler-test.js
@@ -234,6 +234,40 @@ test('unregister destroys the DOM handler for an event after all callbacks have 
   service.unregister('window', 'resize', callback2);
 });
 
+test('soft unregister, unregister will not attempt to unregister a previously unregistered target', function(assert) {
+  assert.expect(1);
+
+  let callback1 = sandbox.stub();
+
+  service.register('window', 'resize', callback1);
+  service.unregister('window', 'resize', callback1);
+  service.unregister('window', 'resize', callback1);
+
+  assert.ok(true, 'Unregister does not throw an exception');
+});
+
+test('soft unregister, unregister will not attempt to unregister a previously unregistered targets event', function(assert) {
+  assert.expect(3);
+
+  let callback1 = sandbox.stub();
+  let callback2 = sandbox.stub();
+
+  service.register('window', 'resize', callback1);
+  service.register('window', 'scroll', callback2);
+
+  service.unregister('window', 'scroll', callback2);
+  service.unregister('window', 'scroll', callback2);
+
+  assert.ok(true, 'Unregister does not throw an exception');
+
+  window.dispatchEvent(new CustomEvent('resize'));
+
+  assert.ok(callback2.notCalled);
+  assert.ok(callback1.calledOnce);
+
+  service.unregister('window', 'resize', callback1);
+});
+
 /* triggerEvent */
 
 test('triggerEvent triggers the event at a throttled rate', function(assert) {


### PR DESCRIPTION
* Adds null checks to unregister to exit method early if the target or targets event is not found.
* Adds tests for both a missing target and a missing targets event.

I was running into issues where I wanted to unregister a handler if the user does some action, but also unregister the handler if the component is destroyed. If unregister was called twice, the method would throw exceptions. 